### PR TITLE
Add possibility for optional certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ module "kubernetes" {
     subnets = ["subnet1", "subnet2", "subnet3"]
 
     proxy_servers = "<proxy with port>"
+    
+    # optional add addtional certificates to the nodes
+    # useful if you have private docker repositories
+    additional-certificates = <<EOF
+-----BEGIN CERTIFICATE-----
+.... 
+-----END CERTIFICATE-----    
+EOF
+    
+    
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module "kubernetes" {
     
     # optional add addtional certificates to the nodes
     # useful if you have private docker repositories
-    additional-certificates = <<EOF
+    additional_certificates = <<EOF
 -----BEGIN CERTIFICATE-----
 .... 
 -----END CERTIFICATE-----    

--- a/certificate.tf
+++ b/certificate.tf
@@ -1,15 +1,8 @@
-data "template_file" "certificate" {
-  template = "${file("${path.module}/certs/certificate_crt.tpl")}"
-
-  vars {
-    certificate = "${var.additional-certificates}"
-  }
-}
 
 resource "aws_s3_bucket_object" "certificate" {
-  count                  = "${var.additional-certificates == "" ? 0 : 1}"
+  count                  = "${var.additional_certificates == "" ? 0 : 1}"
   bucket                 = "${aws_s3_bucket.cluster.id}"
   key                    = "scripts/installation/additional.crt"
-  content                = "${data.template_file.certificate.rendered}"
+  content                = "${var.additional_certificates}"
   server_side_encryption = "AES256"
 }

--- a/certificate.tf
+++ b/certificate.tf
@@ -1,0 +1,15 @@
+data "template_file" "certificate" {
+  template = "${file("${path.module}/certs/certificate_crt.tpl")}"
+
+  vars {
+    certificate = "${var.additional-certificates}"
+  }
+}
+
+resource "aws_s3_bucket_object" "certificate" {
+  count                  = "${var.additional-certificates == "" ? 0 : 1}"
+  bucket                 = "${aws_s3_bucket.cluster.id}"
+  key                    = "scripts/installation/additional.crt"
+  content                = "${data.template_file.certificate.rendered}"
+  server_side_encryption = "AES256"
+}

--- a/certs/certificate_crt.tpl
+++ b/certs/certificate_crt.tpl
@@ -1,0 +1,1 @@
+${certificate}

--- a/certs/certificate_crt.tpl
+++ b/certs/certificate_crt.tpl
@@ -1,1 +1,0 @@
-${certificate}

--- a/input.tf
+++ b/input.tf
@@ -34,6 +34,6 @@ variable "iam_policy" {
    default =   ""
 }
 
-variable "additional-certificates" {
+variable "additional_certificates" {
    default =   ""
 }

--- a/input.tf
+++ b/input.tf
@@ -33,3 +33,7 @@ variable "kubernetes_dashboard_version" {
 variable "iam_policy" {
    default =   ""
 }
+
+variable "additional-certificates" {
+   default =   ""
+}

--- a/scripts/1_prepare.sh
+++ b/scripts/1_prepare.sh
@@ -11,7 +11,12 @@ function set_hostname {
     hostname > /etc/hostname
 }
 
-
+function install_cert {
+    if [ -f /opt/installation/additional.crt ]; then
+       mv /opt/installation/additional.crt /usr/local/share/ca-certificates
+       update-ca-certificates
+    fi
+}
 function setup_docker {
     apt -y install docker.io 
     usermod -a -G docker ubuntu
@@ -112,6 +117,7 @@ function mount_volume {
 
 
 set_hostname
+install_cert
 
 setup_ntp
 setup_docker


### PR DESCRIPTION
if specified in manifest, certificate will be transferred to all nodes
/usr/local/share/ca-certificates/additional.crt 
and installed on the systems with
update-ca-certificates

must be done before  docker start, otherwise docker restart is necassary