### PR TITLE
adding disableSecurityGroupIngress

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -76,3 +76,8 @@ variable "enable_kube2iam" {
   description = "Enable Kube2IAM to add security to AWS API access from pods"
   default     = true
 }
+
+variable "disable_security_group_limit" {
+  description = "use cloud config to set DisableSecurityGroupIngress to true, this will allow more than 50 Load Balancer Service in the cluster"
+  default     = false
+}

--- a/s3.tf
+++ b/s3.tf
@@ -25,6 +25,7 @@ data "template_file" "prepare2" {
   vars {
     kubernetes_version = "${var.kubernetes_version}"
     kubernetes_dashboard_version = "${var.kubernetes_dashboard_version}"
+    disable_security_group_limit = "${var.disable_security_group_limit}"
   }
 }
 


### PR DESCRIPTION
The idea is to use cloud-confg to disable the Security Group limit of 50 Load Balancing Services, by setting to "true" the variable [DisableSecurityGroupIngress](https://medium.com/@marciorag/kubernetes-and-aws-elb-what-to-do-when-you-reach-the-security-group-limit-in-aws-45207e423e) inside cloud config.
2 different syntaxes regarding version upper or lower 1.11.0.